### PR TITLE
Fix storage.sync in firefox

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,12 @@
   "description": "This extension facilitates usage of Github when Asana links are used for branches and/or pull requests",
   "version": "1.0",
 
+  "applications": {
+    "gecko": {
+      "id": "github-asana-link@extension.com"
+    }
+  },
+
   "browser_action": {
     "default_icon": "icon.png",
     "default_popup": "popup.html"


### PR DESCRIPTION
The implementation of storage.sync in Firefox relies on the Add-on ID.

When you install extension via addons:debugging
firefox generates id for you, but seems like
storage.sync doesn't work with temporary id.
We have to specify it explicitly

**Warn**: Google Chrome does not recognize the `applications` key and
 will show a warning if you include it.

When do you need addon-id:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID#When_do_you_need_an_add-on_ID
About applications key:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications